### PR TITLE
Use L1 in diffusion model

### DIFF
--- a/run_test.sh
+++ b/run_test.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+#TT_OPTS=("USE_BF16_IN_L1" "USE_BF16" "USE_FP32")
+TT_OPTS=("USE_BF16_IN_L1" "USE_BF16" "USE_FP32")
+TEST_VALUES=(100 128 256 500 1000)
+
+for opt in "${TT_OPTS[@]}"; do
+    for val in "${TEST_VALUES[@]}"; do
+        echo "Running with TT_BOLTZ_OPT=$opt and test_pairformer[$val]..."
+        TT_BOLTZ_OPT="$opt" pytest -s test_tenstorrent.py::test_pairformer["$val"] \
+            | tee "log_${opt}_pairformer${val}.log"
+    done
+done

--- a/tenstorrent_bf16.py
+++ b/tenstorrent_bf16.py
@@ -480,55 +480,55 @@ class PairformerLayer(Module):
         self, s: ttnn.Tensor, z: ttnn.Tensor
     ) -> Tuple[ttnn.Tensor, ttnn.Tensor]:
 
-        start = time.time()
+        #start = time.time()
         z = ttnn.add(
             z,
             self.triangle_multiplication_start(z),
         )
-        end = time.time()
-        print(f'$$$YF: triangle_multiplication_start time: {end - start:.4f} seconds')
+        #end = time.time()
+        #print(f'$$$YF: triangle_multiplication_start time: {end - start:.4f} seconds')
 
-        start = time.time()
+        #start = time.time()
         z = ttnn.add(
             z,
             self.triangle_multiplication_end(z),
         )
-        end = time.time()
-        print(f'$$$YF: triangle_multiplication_end time: {end - start:.4f} seconds')
+        #end = time.time()
+        #print(f'$$$YF: triangle_multiplication_end time: {end - start:.4f} seconds')
 
-        start = time.time()
+        #start = time.time()
         z = ttnn.add(
             z,
             self.triangle_attention_start(z),
         )
-        end = time.time()
-        print(f'$$$YF: triangle_attention_start time: {end - start:.4f} seconds')
+        #end = time.time()
+        #print(f'$$$YF: triangle_attention_start time: {end - start:.4f} seconds')
 
-        start = time.time()
+        #start = time.time()
         z = ttnn.add(
             z,
             self.triangle_attention_end(z),
         )
-        end = time.time()
-        print(f'$$$YF: triangle_attention_end time: {end - start:.4f} seconds')
+        #end = time.time()
+        #print(f'$$$YF: triangle_attention_end time: {end - start:.4f} seconds')
 
-        start = time.time()
+        #start = time.time()
         z = ttnn.add(z, self.transition_z(z))
-        end = time.time()
-        print(f'$$$YF: transition_z time: {end - start:.4f} seconds')
+        #end = time.time()
+        #print(f'$$$YF: transition_z time: {end - start:.4f} seconds')
 
-        start = time.time()
+        #start = time.time()
         s = ttnn.add(
             s,
             self.attention_pair_bias(s, z),
         )
-        end = time.time()
-        print(f'$$$YF: attention_pair_bias time: {end - start:.4f} seconds')
+        #end = time.time()
+        #print(f'$$$YF: attention_pair_bias time: {end - start:.4f} seconds')
 
-        start = time.time()
+        #start = time.time()
         s = ttnn.add(s, self.transition_s(s))
-        end = time.time()
-        print(f'$$$YF: transition_s time: {end - start:.4f} seconds')
+        #end = time.time()
+        #print(f'$$$YF: transition_s time: {end - start:.4f} seconds')
 
         return s, z
 

--- a/tenstorrent_bf16_l1.py
+++ b/tenstorrent_bf16_l1.py
@@ -543,74 +543,74 @@ class PairformerLayer(Module):
         self, s: ttnn.Tensor, z: ttnn.Tensor
     ) -> Tuple[ttnn.Tensor, ttnn.Tensor]:
 
-        start = time.time()
+        #start = time.time()
         triangle_start_out = self.triangle_multiplication_start(z)
         z = ttnn.add(
             z,
             triangle_start_out,
         )
-        end = time.time()
-        print(f'$$$YF: triangle_multiplication_start time: {end - start:.4f} seconds')
+        #end = time.time()
+        #print(f'$$$YF: triangle_multiplication_start time: {end - start:.4f} seconds')
         ttnn.deallocate(triangle_start_out)
 
-        start = time.time()
+        #start = time.time()
         triangle_end_out = self.triangle_multiplication_end(z)
         z = ttnn.add(
             z,
             triangle_end_out,
         )
-        end = time.time()
-        print(f'$$$YF: triangle_multiplication_end time: {end - start:.4f} seconds')
+        #end = time.time()
+        #print(f'$$$YF: triangle_multiplication_end time: {end - start:.4f} seconds')
         ttnn.deallocate(triangle_end_out)
 
-        start = time.time()
+        #start = time.time()
         triangle_attention_start_out = self.triangle_attention_start(z)
         z = ttnn.add(
             z,
             triangle_attention_start_out,
         )
-        end = time.time()
-        print(f'$$$YF: triangle_attention_start time: {end - start:.4f} seconds')
+        #end = time.time()
+        #print(f'$$$YF: triangle_attention_start time: {end - start:.4f} seconds')
         ttnn.deallocate(triangle_attention_start_out)
 
-        start = time.time()
+        #start = time.time()
         triangle_attention_end_out = self.triangle_attention_end(z)
         z = ttnn.add(
             z,
             triangle_attention_end_out,
         )
-        end = time.time()
-        print(f'$$$YF: triangle_attention_end time: {end - start:.4f} seconds')
+        #end = time.time()
+        #print(f'$$$YF: triangle_attention_end time: {end - start:.4f} seconds')
         ttnn.deallocate(triangle_attention_end_out)
 
-        start = time.time()
+        #start = time.time()
         transition_z_out = self.transition_z(z)
         z = ttnn.add(
             z, 
             transition_z_out, 
         )
-        end = time.time()
-        print(f'$$$YF: transition_z time: {end - start:.4f} seconds')
+        #end = time.time()
+        #print(f'$$$YF: transition_z time: {end - start:.4f} seconds')
         ttnn.deallocate(transition_z_out)
 
-        start = time.time()
+        #start = time.time()
         attention_pair_bias_out = self.attention_pair_bias(s, z)
         s = ttnn.add(
             s,
             attention_pair_bias_out,
         )
-        end = time.time()
-        print(f'$$$YF: attention_pair_bias time: {end - start:.4f} seconds')
+        #end = time.time()
+        #print(f'$$$YF: attention_pair_bias time: {end - start:.4f} seconds')
         ttnn.deallocate(attention_pair_bias_out)
 
-        start = time.time()
+        #start = time.time()
         transition_s_out = self.transition_s(s)
         s = ttnn.add(
             s, 
             transition_s_out, 
         )
-        end = time.time()
-        print(f'$$$YF: transition_s time: {end - start:.4f} seconds')
+        #end = time.time()
+        #print(f'$$$YF: transition_s time: {end - start:.4f} seconds')
         ttnn.deallocate(transition_s_out)
 
         return s, z
@@ -795,10 +795,10 @@ class DiffusionTransformer(Module):
         if self.z is None:
             self.z = z
         for layer in self.layers:
-            start = time.time()
+            #start = time.time()
             a = layer(a, s, self.z)
-            end = time.time()
-            print(f'$$$YF: DiffusionTransformerLayer time: {end - start:.4f} seconds')
+            #end = time.time()
+            #print(f'$$$YF: DiffusionTransformerLayer time: {end - start:.4f} seconds')
         return a
 
 

--- a/tenstorrent_fp32.py
+++ b/tenstorrent_fp32.py
@@ -479,55 +479,55 @@ class PairformerLayer(Module):
         self, s: ttnn.Tensor, z: ttnn.Tensor
     ) -> Tuple[ttnn.Tensor, ttnn.Tensor]:
 
-        start = time.time()
+        #start = time.time()
         z = ttnn.add(
             z,
             self.triangle_multiplication_start(z),
         )
-        end = time.time()
-        print(f'$$$YF: triangle_multiplication_start time: {end - start:.4f} seconds')
+        #end = time.time()
+        #print(f'$$$YF: triangle_multiplication_start time: {end - start:.4f} seconds')
 
-        start = time.time()
+        #start = time.time()
         z = ttnn.add(
             z,
             self.triangle_multiplication_end(z),
         )
-        end = time.time()
-        print(f'$$$YF: triangle_multiplication_end time: {end - start:.4f} seconds')
+        #end = time.time()
+        #print(f'$$$YF: triangle_multiplication_end time: {end - start:.4f} seconds')
 
-        start = time.time()
+        #start = time.time()
         z = ttnn.add(
             z,
             self.triangle_attention_start(z),
         )
-        end = time.time()
-        print(f'$$$YF: triangle_attention_start time: {end - start:.4f} seconds')
+        #end = time.time()
+        #print(f'$$$YF: triangle_attention_start time: {end - start:.4f} seconds')
 
-        start = time.time()
+        #start = time.time()
         z = ttnn.add(
             z,
             self.triangle_attention_end(z),
         )
-        end = time.time()
-        print(f'$$$YF: triangle_attention_end time: {end - start:.4f} seconds')
+        #end = time.time()
+        #print(f'$$$YF: triangle_attention_end time: {end - start:.4f} seconds')
 
-        start = time.time()
+        #start = time.time()
         z = ttnn.add(z, self.transition_z(z))
-        end = time.time()
-        print(f'$$$YF: transition_z time: {end - start:.4f} seconds')
+        #end = time.time()
+        #print(f'$$$YF: transition_z time: {end - start:.4f} seconds')
 
-        start = time.time()
+        #start = time.time()
         s = ttnn.add(
             s,
             self.attention_pair_bias(s, z),
         )
-        end = time.time()
-        print(f'$$$YF: attention_pair_bias time: {end - start:.4f} seconds')
+        #end = time.time()
+        #print(f'$$$YF: attention_pair_bias time: {end - start:.4f} seconds')
 
-        start = time.time()
+        #start = time.time()
         s = ttnn.add(s, self.transition_s(s))
-        end = time.time()
-        print(f'$$$YF: transition_s time: {end - start:.4f} seconds')
+        #end = time.time()
+        #print(f'$$$YF: transition_s time: {end - start:.4f} seconds')
 
         return s, z
 


### PR DESCRIPTION
## Summary by Sourcery

Enable L1 memory configuration for key operators in the bf16_l1 diffusion model, disable inline profiling logs across all model variants, and introduce a test runner script.

New Features:
- Enable L1 memory configuration for layer_norm and linear operations in the bf16_l1 model variant.

Enhancements:
- Comment out timing and debug print statements in bf16_l1, bf16, and fp32 diffusion modules to disable profiling.

Tests:
- Add run_test.sh to automate pytest runs across different TT_BOLTZ_OPT settings and input sizes.